### PR TITLE
fix: the logic of the option --progress-only

### DIFF
--- a/ffmpeg_progress_yield/__main__.py
+++ b/ffmpeg_progress_yield/__main__.py
@@ -47,9 +47,9 @@ def main() -> None:
         for progress in ff.run_command_with_progress():
             print(f"{progress}/100")
 
-    if args.progress_only and platform.system() == "Windows":
-        print("\x1b[K")
-    else:
+    if platform.system() == "Windows":
+        print("\x1b[K", end="")
+    if not args.progress_only:
         print(ff.stderr)
 
 


### PR DESCRIPTION
Sorry for making commit again so quickly.

I noticed the output would differ in Windows and *nix, so I changed the print to print escape sequence without newline in Windows. Moreover, the escape sequence will be printed certainly on Windows but it doesn't matter.

And I make the option influence the segment "print(ff.stderr)" only so that do not make more confusion.
(The condition args.progress_only and platform.system() == "Windows" means that the option is only available in Windows.)

That is it.