### PR TITLE
Add support to send ffmpeg output to a file

### DIFF
--- a/ffmpeg_progress_yield/__init__.py
+++ b/ffmpeg_progress_yield/__init__.py
@@ -1,5 +1,5 @@
 from .ffmpeg_progress_yield import FfmpegProgress
 
-__version__ = "0.11.3"
+__version__ = "0.11.4"
 
 __all__ = ["FfmpegProgress"]

--- a/ffmpeg_progress_yield/__init__.py
+++ b/ffmpeg_progress_yield/__init__.py
@@ -1,5 +1,5 @@
 from .ffmpeg_progress_yield import FfmpegProgress
 
-__version__ = "0.11.4"
+__version__ = "0.12.0"
 
 __all__ = ["FfmpegProgress"]

--- a/ffmpeg_progress_yield/__main__.py
+++ b/ffmpeg_progress_yield/__main__.py
@@ -26,6 +26,18 @@ def main() -> None:
         help="Print progress only and do not print stderr at exit.",
     )
     parser.add_argument(
+        "-x",
+        "--exclude-progress",
+        action="store_true",
+        help="Exclude progress lines from ffmpeg log.",
+    )
+    parser.add_argument(
+        "-l",
+        "--log-file",
+        type=str,
+        help="Send ffmpeg log output to specified file.",
+    )
+    parser.add_argument(
         "ffmpeg_command",
         type=str,
         nargs=argparse.REMAINDER,
@@ -33,7 +45,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    ff = FfmpegProgress(args.ffmpeg_command, dry_run=args.dry_run)
+    ff = FfmpegProgress(args.ffmpeg_command, dry_run=args.dry_run, exclude_progress=args.exclude_progress)
 
     try:
         from tqdm import tqdm
@@ -55,8 +67,15 @@ def main() -> None:
 
     if platform.system() == "Windows":
         print("\x1b[K", end="")
+
     if not args.progress_only:
-        print(ff.stderr)
+        log_file = args.log_file
+        if log_file in ("1", "2"):
+            log_file = int(log_file)
+        elif log_file is None:
+            log_file = 2
+        with open(log_file, "w") as f:
+            print(ff.stderr, file=f)
 
 
 if __name__ == "__main__":

--- a/test/test.py
+++ b/test/test.py
@@ -115,8 +115,7 @@ class TestLibrary:
                 break
 
     def test_progress_with_loglevel_error(self):
-        cmd = TestLibrary.cmd
-        cmd.extend(["-loglevel", "error"])
+        cmd = TestLibrary.cmd + ["-loglevel", "error"]
         ff = FfmpegProgress(cmd)
         for progress in ff.run_command_with_progress():
             print(f"{progress}/100")
@@ -124,6 +123,23 @@ class TestLibrary:
                 assert 0 < progress < 100
                 break
 
+    def test_stderr_without_progress(self):
+        ff = FfmpegProgress(TestLibrary.cmd, exclude_progress=True)
+        for progress in ff.run_command_with_progress():
+            print(f"{progress}/100")
+            if progress > 0 and ff.stderr is not None:
+                assert len(ff.stderr) > 0
+                break
+        assert "out_time=" not in ff.stderr
+
+    def test_stderr_with_progress(self):
+        ff = FfmpegProgress(TestLibrary.cmd, exclude_progress=False)
+        for progress in ff.run_command_with_progress():
+            print(f"{progress}/100")
+            if progress > 0 and ff.stderr is not None:
+                assert len(ff.stderr) > 0
+                break
+        assert "out_time=" in ff.stderr
 
 class TestProgress:
     def test_progress(self):


### PR DESCRIPTION
The idea is to support sending the output of ffmpeg to a different file than the progress bar, having the option to filter out the ffmpeg progress lines.