### PR TITLE
pyproject: Remove deprecated license classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ keywords = ["ffmpeg"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
License-Classifier have been deprecated with [PEP-639](https://peps.python.org/pep-0639/) and should not be used anymore.