### PR TITLE
Do not set bar position

### DIFF
--- a/src/ffmpeg_progress_yield/__main__.py
+++ b/src/ffmpeg_progress_yield/__main__.py
@@ -61,7 +61,6 @@ def main() -> None:
 
             with tqdm(
                 total=100,
-                position=1,
                 desc="Progress",
                 bar_format="{desc}: {percentage:3.2f}% |{bar}{r_bar}",
             ) as pbar:


### PR DESCRIPTION
The cleanup of the bar in progress-only mode is broken with `position=1`.

This is the output after the script finished with `position=1`. You can see, that the new shell prompt is overwriting halve of the bar and the full bar is printed again in the empty row above the bar output:
<img width="633" height="112" alt="2025-10-17-194329_633x112_scrot" src="https://github.com/user-attachments/assets/bbdb6f22-e6fb-4028-8b01-6fb9712c7954" />

This is the fixed output without `position=1`:
<img width="633" height="112" alt="2025-10-17-194304_633x112_scrot" src="https://github.com/user-attachments/assets/87652107-bc82-4be2-9fcc-7a2d9c1d3958" />


Here is a screen recoding of the broken output:

https://github.com/user-attachments/assets/741f9e72-d1e1-4b7b-8312-91b0b63bb023

